### PR TITLE
Tag support added to FragmentTransactionExtended class

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Example:
 ```java
 FragmentManager fm = getFragmentManager();
 FragmentTransaction fragmentTransaction = fm.beginTransaction();
-FragmentTransactionExtended fragmentTransactionExtended = new FragmentTransactionExtended(this, fragmentTransaction, firstFragment, secondFragment, R.id.fragment_place);
+FragmentTransactionExtended fragmentTransactionExtended = new FragmentTransactionExtended(this, fragmentTransaction, firstFragment, secondFragment, R.id.fragment_place, tag);
 fragmentTransactionExtended.addTransition(FragmentTransactionExtended.GLIDE);
 fragmentTransactionExtended.commit();
 ```

--- a/libraryFragmentTransactionExtended/src/main/java/com/desarrollodroide/libraryfragmenttransactionextended/FragmentTransactionExtended.java
+++ b/libraryFragmentTransactionExtended/src/main/java/com/desarrollodroide/libraryfragmenttransactionextended/FragmentTransactionExtended.java
@@ -23,6 +23,7 @@ public class FragmentTransactionExtended implements FragmentManager.OnBackStackC
     private Fragment mFirstFragment, mSecondFragment;
     private int mContainerID;
     private int mTransitionType;
+    private String mTag;
     public static final int SCALEX = 0;
     public static final int SCALEY = 1;
     public static final int SCALEXY = 2;
@@ -53,6 +54,16 @@ public class FragmentTransactionExtended implements FragmentManager.OnBackStackC
         this.mFirstFragment = firstFragment;
         this.mSecondFragment = secondFragment;
         this.mContainerID = containerID;
+        this.mTag = null;
+    }
+
+    public FragmentTransactionExtended(Context context, FragmentTransaction fragmentTransaction, Fragment firstFragment, Fragment secondFragment, int containerID, String tag) {
+        this.mFragmentTransaction = fragmentTransaction;
+        this.mContext = context;
+        this.mFirstFragment = firstFragment;
+        this.mSecondFragment = secondFragment;
+        this.mContainerID = containerID;
+        this.mTag = tag;
     }
 
     public void addTransition(int transitionType) {
@@ -234,7 +245,7 @@ public class FragmentTransactionExtended implements FragmentManager.OnBackStackC
                 @Override
                 public void onAnimationEnd(Animator arg0) {
                     mFragmentTransaction.setCustomAnimations(R.animator.slide_fragment_in, 0, 0, R.animator.slide_fragment_out);
-                    mFragmentTransaction.add(mContainerID, mSecondFragment);
+                    mFragmentTransaction.add(mContainerID, mSecondFragment, mTag);
                     mFragmentTransaction.addToBackStack(null);
                     mFragmentTransaction.commit();
                 }


### PR DESCRIPTION
There was no way to add tags to the fragment being placed in the container during a FragmentTransactionExtended transaction.

I created a new constructor that accepts a tag as a String and sets a member variable to it.
In the original constructor, I set the member tag to null.

I changed the fragmentTransaction.add(containerId, fragment) method to fragmentTransaction.add(containerId, fragment, tag) 
This is flexible, as the fragmentTransaction.add(containerId, fragment) method is actually fragmentTransaction.add(containerId, fragment, null)
